### PR TITLE
フォント追加と、 layout document 導入

### DIFF
--- a/src/components/custom-head.tsx
+++ b/src/components/custom-head.tsx
@@ -4,14 +4,6 @@ const CustomHead = ({ titlePre = '' }) => {
   return (
     <Head>
       <title>前島 悠人{titlePre ? ` | ${titlePre}` : ''}</title>
-      <meta name="description" content="とっても自由な Web エンジニアがプロダクト開発でどこまでいけるかの挑戦を見守るサイトです。" />
-      <link rel="apple-touch-icon" sizes="180x180" href="/favicon/apple-touch-icon.png" />
-      <link rel="icon" type="image/png" sizes="32x32" href="/favicon/favicon-32x32.png" />
-      <link rel="icon" type="image/png" sizes="16x16" href="/favicon/favicon-16x16.png" />
-      <link rel="manifest" href="/favicon/site.webmanifest" />
-      <link rel="mask-icon" href="/favicon/safari-pinned-tab.svg" color="#5bbad5" />
-      <meta name="msapplication-TileColor" content="#da532c" />
-      <meta name="theme-color" content="#ffffff"></meta>
     </Head>
   )
 }

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -1,0 +1,10 @@
+import Header from './header'
+
+export default function Layout({ children }) {
+  return (
+    <>
+      <Header />
+      <main>{children}</main>
+    </>
+  )
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,8 +1,13 @@
 import '../styles/globals.css'
 import type { AppProps } from 'next/app'
+import Layout from '../components/Layout'
 
 function MyApp({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />
+  return (
+    <Layout>
+      <Component {...pageProps} />
+    </Layout>
+  )
 }
 
 export default MyApp

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,6 +1,6 @@
 import '../styles/globals.css'
 import type { AppProps } from 'next/app'
-import Layout from '../components/Layout'
+import Layout from '../components/layout'
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,0 +1,35 @@
+import Document, { Html, Head, Main, NextScript, DocumentContext } from 'next/document'
+
+class MyDocument extends Document {
+  static async getInitialProps(ctx: DocumentContext) {
+    const initialProps = await Document.getInitialProps(ctx)
+    return { ...initialProps }
+  }
+
+  render() {
+    return (
+      <Html>
+        <Head>
+          <meta name="description" content="とっても自由な Web エンジニアがプロダクト開発でどこまでいけるかの挑戦を見守るサイトです。" />
+          <link rel="apple-touch-icon" sizes="180x180" href="/favicon/apple-touch-icon.png" />
+          <link rel="icon" type="image/png" sizes="32x32" href="/favicon/favicon-32x32.png" />
+          <link rel="icon" type="image/png" sizes="16x16" href="/favicon/favicon-16x16.png" />
+          <link rel="manifest" href="/favicon/site.webmanifest" />
+          <link rel="mask-icon" href="/favicon/safari-pinned-tab.svg" color="#5bbad5" />
+          <meta name="msapplication-TileColor" content="#da532c" />
+          <meta name="theme-color" content="#ffffff"></meta>
+          <link
+            href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@500&display=swap"
+            rel="stylesheet"
+          />
+        </Head>
+        <body className="font-body">
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    )
+  }
+}
+
+export default MyDocument

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -19,7 +19,7 @@ class MyDocument extends Document {
           <meta name="msapplication-TileColor" content="#da532c" />
           <meta name="theme-color" content="#ffffff"></meta>
           <link
-            href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@500&display=swap"
+            href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&display=swap"
             rel="stylesheet"
           />
         </Head>

--- a/src/pages/blog/[slug].tsx
+++ b/src/pages/blog/[slug].tsx
@@ -144,7 +144,6 @@ const RenderPost = ({ post, redirect, preview }) => {
   return (
     <>
       <CustomHead titlePre={post.Page} />
-      <Header />
       {preview && (
         <div className={blogStyles.previewAlertContainer}>
           <div className={blogStyles.previewAlert}>

--- a/src/pages/blog/[slug].tsx
+++ b/src/pages/blog/[slug].tsx
@@ -1,4 +1,3 @@
-import Image from 'next/image'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import fetch from 'node-fetch'
@@ -7,7 +6,6 @@ import React, { CSSProperties, useEffect } from 'react'
 
 import components from '../../components/dynamic'
 import CustomHead from '../../components/custom-head'
-import Header from '../../components/header'
 import TopicPaths from '../../components/topic-path'
 import Heading from '../../components/heading'
 import getBlogIndex from '../../lib/notion/getBlogIndex'

--- a/src/pages/blog/index.tsx
+++ b/src/pages/blog/index.tsx
@@ -1,7 +1,6 @@
 import Link from 'next/link'
 
 import CustomHead from '../../components/custom-head'
-import Header from '../../components/header'
 import TopicPaths from '../../components/topic-path'
 import blogStyles from '../../styles/blog.module.css'
 

--- a/src/pages/blog/index.tsx
+++ b/src/pages/blog/index.tsx
@@ -39,7 +39,6 @@ const Index = ({ posts = [], preview }) => {
   return (
     <>
       <CustomHead titlePre="Home" />
-      <Header />
       {/* TODO: この preview の意味がわからない */}
       {preview && (
         <div>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,7 +2,6 @@ import type { NextPage } from 'next'
 import Link from 'next/link'
 
 import CustomHead from '../components/custom-head'
-import Header from '../components/header'
 
 const Home: NextPage = () => {
   return (

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,18 +6,15 @@ import Header from '../components/header'
 
 const Home: NextPage = () => {
   return (
-    <div>
+    <>
       <CustomHead titlePre="Home" />
-      <Header />
-      <main>
-        <h1>
-          サイトのタイトル
-        </h1>
-        <Link href="/blog" passHref>
-          <a className="text-blue-600">blog</a>
-        </Link>
-      </main>
-    </div>
+      <h1>
+        サイトのタイトル
+      </h1>
+      <Link href="/blog" passHref>
+        <a className="text-blue-600">blog</a>
+      </Link>
+    </>
   )
 }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,6 +3,9 @@ module.exports = {
   purge: ['./src/pages/**/*.{js,ts,jsx,tsx}', './src/components/**/*.{js,ts,jsx,tsx}'],
   darkMode: false, // or 'media' or 'class'
   theme: {
+    fontFamily: {
+      body: ['Noto Sans JP', 'Helvetica Neue', 'Arial', 'Hiragino Kaku Gothic ProN', 'Hiragino Sans', 'Meiryo', 'sans-serif'],
+    },
     extend: {},
   },
   variants: {


### PR DESCRIPTION

## ref

- Noto Sans JP", "Helvetica Neue", Arial, "Hiragino Kaku Gothic ProN", "Hiragino Sans", Meiryo, sans-serif; from yamotty
- Noto Sans JP,Helvetica,Apple Color Emoji,Segoe UI Emoji,NotoColorEmoji,Noto Color Emoji,Segoe UI Symbol,Android Emoji,EmojiSymbols,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Noto Sans,sans-serif; from https://morizooo.me/