### PR TITLE
remove: <reference types="next/types/global" />

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="next" />
-/// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited


### PR DESCRIPTION
this change was created from below commit
140f0c0 Merge pull request #42 from maejimayuto/dependabot/npm_and_yarn/next-12.0.5

it's cause by next js version up
12.0.4 -> 12.0.5
https://github.com/vercel/next.js/releases/tag/v12.0.5